### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ IASequentialDownloadManager, will help you download a set of urls in a sequentia
 
 ###Installation
 ####Using CocoaPods (Recommended)
-1. Install CocoaPods on your machine [Cocoapods](http://cocoapods.org/)
+1. Install CocoaPods on your machine [CocoaPods](http://cocoapods.org/)
 2. Create a `Podfile`
 3. Add `pod 'IADownloadManager'` to your Podfile
 4. in the Terminal run 'pod install'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
